### PR TITLE
修改 composer 设置

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=5.6",
-        "guzzlehttp/guzzle": "5.3"
+        "guzzlehttp/guzzle": ">=5.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
guzzlehttp/guzzle 扩展应当设置为大于等于 5.3，防止应用需要更高版本的扩展